### PR TITLE
Allow `hybrid_config` type to be any pathlike, e.g. `pathlib.Path`

### DIFF
--- a/eFFORT/hybrid/hybrid_model.py
+++ b/eFFORT/hybrid/hybrid_model.py
@@ -1,7 +1,7 @@
 import json
 from os import PathLike
 from pathlib import Path
-from typing import Union
+from typing import AnyStr, Union
 
 import numpy
 import pandas
@@ -15,7 +15,7 @@ class Hybrid:
 
     """
 
-    def __init__(self, hybrid_config: Union[str, bytes, PathLike] = None) -> None:
+    def __init__(self, hybrid_config: Union[AnyStr, PathLike] = None) -> None:
         """Initialize the hybrid weight with the given configuration.
 
         The default binning is given by

--- a/eFFORT/hybrid/hybrid_model.py
+++ b/eFFORT/hybrid/hybrid_model.py
@@ -1,5 +1,7 @@
 import json
+from os import PathLike
 from pathlib import Path
+from typing import Union
 
 import numpy
 import pandas
@@ -13,7 +15,7 @@ class Hybrid:
 
     """
 
-    def __init__(self, hybrid_config: str = None) -> None:
+    def __init__(self, hybrid_config: Union[str, bytes, PathLike] = None) -> None:
         """Initialize the hybrid weight with the given configuration.
 
         The default binning is given by


### PR DESCRIPTION
By default, if it is None, it is initalized to a pathlib.Path, which resulted inmypy errors when I opened the file in emacs:

```
   hybrid_model.py    38  29 error Incompatible types in assignment (expression has type "Path", variable has type "Optional[str]") (python-mypy)

   hybrid_model.py    40  19 error Argument 1 to "open" has incompatible type "Optional[str]"; expected "Union[str, bytes, int, _PathLike[Any]]" (python-mypy)
```

Fixed it with `Union[str, bytes, os.PathLike]`. I probably also could have used `AnyStr` instead of `str, bytes`.

See e.g. (or google for yourself):
- https://stackoverflow.com/questions/53418046/how-do-i-type-hint-a-filename-in-a-function
- https://github.com/python/typing/issues/402
- https://github.com/python/typeshed/pull/991