### PR TITLE
Add newline to prevent sphinx compilation warning

### DIFF
--- a/eFFORT/hybrid/hybrid_model.py
+++ b/eFFORT/hybrid/hybrid_model.py
@@ -100,6 +100,7 @@ class Hybrid:
           * El_B: the lepton momentum in the B reference frame.
           * q2: the momentum transfer to the lepton-neutrino system.
           * __weight__: the weight should be adapted in a way that the individual components have the correct relative branching fractions.
+
         The given names are defaults from hybrid_binning.json, alternative names can be set there.
 
         Parameters


### PR DESCRIPTION
Otherwise, when I run `make clean && make html` in the `docs` directory, I get the warning:

    eFFORT/eFFORT/hybrid/hybrid_model.py:docstring of eFFORT.hybrid.hybrid_model.Hybrid.generate_hybrid_weights:10: WARNING: Definition list ends without a blank line; unexpected unindent.

I compared the generated html and it seems this doesn't change anything, so despite the warning sphinx was able to handle the missing blank line. Still, nicer to be warning free.